### PR TITLE
Add Hugging Face Spaces demo to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Style transfer of audio effects with differentiable signal processing
 [![Demo](https://img.shields.io/badge/Web-Demo-blue)](https://csteinmetz1.github.io/DeepAFx-ST)
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](TBD)
 [![arXiv](https://img.shields.io/badge/arXiv-2207.08759-b31b1b.svg)](https://arxiv.org/abs/2207.08759)
+[![Hugging Face Spaces](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Spaces-blue)](https://huggingface.co/spaces/nateraw/deepafx-st)
 
 <!-- <img width="700px" src="docs/new-generic-style-transfer-headline.svg"> -->
  


### PR DESCRIPTION
The following adds a link to a demo of this model on Hugging Face Spaces. This is nice because folks can easily try out the models with any files they want (or the provided examples). You can check out the demo here: [![Hugging Face Spaces](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Spaces-blue)](https://huggingface.co/spaces/nateraw/deepafx-st)